### PR TITLE
Add support for request idempotency keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,14 @@ jobs:
             os: ubuntu-latest
             rust: 1.65.0
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        default: true
-    - run: cargo test -- --test-threads=1
-      env:
-        ORB_API_KEY: ${{ secrets.ORB_API_KEY }}
-
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          default: true
+      - run: cargo test -- --test-threads=1
+        env:
+          ORB_API_KEY: ${{ secrets.ORB_API_KEY }}
   fmt:
     name: fmt
     runs-on: ubuntu-latest
@@ -41,7 +40,6 @@ jobs:
         default: true
         components: rustfmt
     - run: cargo fmt -- --check
-
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 categories = ["api-bindings", "web-programming"]
 keywords = ["orb", "billing", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-orb-billing"
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.65"
 edition = "2021"
 

--- a/src/client/customers.rs
+++ b/src/client/customers.rs
@@ -82,7 +82,7 @@ pub struct CreateCustomerRequest<'a> {
     pub tax_id: Option<TaxIdRequest<'a>>,
     /// An idempotency key can ensure that if the same request comes in
     /// multiple times in a 48-hour period, only one makes changes.
-    /// NOTE: this is passed in a request header, not the body
+    // NOTE: this is passed in a request header, not the body
     #[serde(skip_serializing)]
     pub idempotency_key: Option<&'a str>,
 }

--- a/src/client/plans.rs
+++ b/src/client/plans.rs
@@ -52,7 +52,7 @@ pub struct Plan {
     #[serde(rename = "external_plan_id")]
     pub external_id: Option<String>,
     /// A human-readable name for the plan.
-    pub name: String,
+    pub name: Option<String>,
     /// A human-readable description of the plan.
     pub description: String,
     /// The time at which the plan was created.

--- a/src/client/subscriptions.rs
+++ b/src/client/subscriptions.rs
@@ -78,7 +78,7 @@ pub struct CreateSubscriptionRequest<'a> {
     pub default_invoice_memo: Option<&'a str>,
     /// An idempotency key can ensure that if the same request comes in
     /// multiple times in a 48-hour period, only one makes changes.
-    /// NOTE: this is passed in a request header, not the body
+    // NOTE: this is passed in a request header, not the body
     #[serde(skip_serializing)]
     pub idempotency_key: Option<&'a str>,
 }


### PR DESCRIPTION
As per the upstream Orb documentation at
https://docs.withorb.com/docs/orb-docs/idempotency, it's possible to
want to issue two identical requests repeatedly; adding an idempotency
key allows Orb to treat them as the same request, and not re-create
objects.

This adds support for idempotency keys to creating customer and
subscription objects.