### PR TITLE
Add support for plan metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
         include:
           - build: macos
             os: macos-latest
-            rust: 1.65.0
+            rust: 1.67.0
           - build: ubuntu
             os: ubuntu-latest
-            rust: 1.65.0
+            rust: 1.67.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: 1.67.0
         default: true
         components: rustfmt
     - run: cargo fmt -- --check
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.65.0
+        toolchain: 1.67.0
         default: true
         components: clippy
     - uses: actions-rs/clippy-check@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning].
 ## [Unreleased] <!-- #release:date -->
 
 * Add support for Plan metadata.
+* Bump MSRV to 1.67.
 
 ## [0.6.0] - 2023-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Add support for Plan metadata.
+
 ## [0.6.0] - 2023-05-12
+
+* Modified the `InvoiceSubscription` field to be optional.
 
 ## [0.5.0] - 2023-05-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["api-bindings", "web-programming"]
 keywords = ["orb", "billing", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-orb-billing"
 version = "0.6.0"
-rust-version = "1.65"
+rust-version = "1.67"
 edition = "2021"
 
 [dependencies]

--- a/src/client/plans.rs
+++ b/src/client/plans.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use futures_core::Stream;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
@@ -58,6 +60,9 @@ pub struct Plan {
     /// The time at which the plan was created.
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
+    /// Arbitrary metadata that is attached to the plan. Cannot be nested, must have string values.
+    #[serde(default)]
+    pub metadata: BTreeMap<String, String>,
     // TODO: many missing fields.
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -503,6 +503,10 @@ async fn test_subscriptions() {
 
         assert_eq!(subscription.customer.id, customer.id);
         assert_eq!(subscription.plan.external_id.as_deref(), Some("test"));
+        assert_eq!(
+            subscription.plan.metadata.get("purpose"),
+            Some(&"test".to_string())
+        );
         assert_eq!(subscription.net_terms, 3);
         assert!(subscription.auto_collection);
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -76,7 +76,7 @@ async fn delete_all_test_customers(client: &Client) {
         .list_customers(&MAX_PAGE_LIST_PARAMS)
         .try_filter(|customer| future::ready(customer.name.starts_with(TEST_PREFIX)))
         .try_for_each_concurrent(Some(CONCURRENCY_LIMIT), |customer| async move {
-            info!(%customer.id, "deleting custome");
+            info!(%customer.id, "deleting customer");
             client.delete_customer(&customer.id).await
         })
         .await
@@ -87,11 +87,11 @@ async fn create_test_customer(client: &Client, i: usize) -> Customer {
     client
         .create_customer(&CreateCustomerRequest {
             name: &format!("{TEST_PREFIX}-{i}"),
-            email: "orb-testing-{i}@materialize.com",
+            email: &format!("orb-testing-{i}@materialize.com"),
             external_id: None,
             payment_provider: Some(CustomerPaymentProviderRequest {
                 kind: PaymentProvider::Stripe,
-                id: "cus_fake_{i}",
+                id: &format!("cus_fake_{i}"),
             }),
             ..Default::default()
         })


### PR DESCRIPTION
Orb now allows users to attach arbitrary key/value metadata to plans. Add support for this to the crate.

Additionally, clean up some test data where we weren't actually interpolating locals.