### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+## [0.7.0] - 2023-12-18
+
 * Add support for Plan metadata.
 * Add support for creating customer ledger entries.
 * Add support for enumerating customer credit balances.
@@ -49,7 +51,8 @@ Versioning].
 Initial release.
 
 <!-- #release:next-url -->
-[Unreleased]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/MaterializeInc/rust-orb-billing/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 categories = ["api-bindings", "web-programming"]
 keywords = ["orb", "billing", "api", "sdk"]
 repository = "https://github.com/MaterializeInc/rust-orb-billing"
-version = "0.6.0"
+version = "0.7.0"
 rust-version = "1.70"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ An async Rust API client for the [Orb] billing platform.
 ```
 # Cargo.toml
 [dependencies]
-orb-billing = "0.6.0"
+orb-billing = "0.7.0"
 ```
 
-**[View documentation.](https://docs.rs/orb-billing/0.6.0)**
+**[View documentation.](https://docs.rs/orb-billing/0.7.0)**
 
 [Orb]: https://withorb.com


### PR DESCRIPTION
The tag has already been pushed, so it should be a matter of merging this and running `cargo publish`.