### PR TITLE
Export the underlying Orb ApiError struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Export the Orb `ApiError` struct.
+
 ## [0.7.1] - 2023-12-19
 
 * Fix bug preventing customer costs from being filtered by `timeframe_start`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,4 +68,4 @@ pub use client::subscriptions::{
 pub use client::taxes::{TaxId, TaxIdRequest, TaxIdType};
 pub use client::Client;
 pub use config::{ClientBuilder, ClientConfig, ListParams};
-pub use error::Error;
+pub use error::{ApiError, Error};


### PR DESCRIPTION
This improves the ability for clients to handle errors.