### PR TITLE
Add `base_plan_id` to `Plan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Add `base_plan_id` to `Plan`.
+
 ## [0.7.2] - 2024-01-03
 
 * Export the Orb `ApiError` struct.

--- a/src/client/plans.rs
+++ b/src/client/plans.rs
@@ -60,6 +60,9 @@ pub struct Plan {
     /// The time at which the plan was created.
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
+    /// The parent plan id if the given plan was created by overriding one or more of the parent's
+    /// prices.
+    pub base_plan_id: Option<String>,
     /// Arbitrary metadata that is attached to the plan. Cannot be nested, must have string values.
     #[serde(default)]
     pub metadata: BTreeMap<String, String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use client::invoices::{
     Invoice, InvoiceCustomer, InvoiceListParams, InvoiceStatusFilter, InvoiceSubscription,
 };
 pub use client::marketplaces::ExternalMarketplace;
-pub use client::plans::PlanId;
+pub use client::plans::{Plan, PlanId};
 pub use client::subscriptions::{
     CreateSubscriptionRequest, Subscription, SubscriptionListParams, SubscriptionStatus,
 };

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -534,6 +534,7 @@ async fn test_plans() {
     // TODO: validate list results.
     // TODO: test get_plan.
     // TODO: test get_plan_by_external_id.
+    // TODO: test get_plan w/nested plans?
     // Testing the above will be hard as there is no API to create plans.
 }
 


### PR DESCRIPTION
I could have also added the full `base_plan` object but don't have a plan configured in the test account to make me 100% freestyling the struct. This is safer and will get the job done.