### PR TITLE
Mark price matrix dimension values as nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Fix bug causing deserialization errors when `get_customer_costs` responses
+  contained null price dimension values.
+
 ## [0.8.0] - 2024-01-05
 
 * Add `base_plan_id` to `Plan`.

--- a/src/client/customers.rs
+++ b/src/client/customers.rs
@@ -606,7 +606,7 @@ pub struct CustomerCostPriceBlockMatrixPriceConfig {
     /// The fallback unit amount.
     pub default_unit_amount: String,
     /// A collection of dimensions modeled by the matrix.
-    pub dimensions: Vec<String>,
+    pub dimensions: Vec<Option<String>>,
     /// All pricing values configured for the matrix.
     pub matrix_values: Vec<CustomerCostPriceBlockMatrixPriceValue>,
 }
@@ -615,7 +615,7 @@ pub struct CustomerCostPriceBlockMatrixPriceConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CustomerCostPriceBlockMatrixPriceValue {
     /// The dimensions corresponding to this cell.
-    pub dimension_values: Vec<String>,
+    pub dimension_values: Vec<Option<String>>,
     /// The per-unit amount usage within this cell bills.
     pub unit_amount: String,
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -697,8 +697,8 @@ async fn test_customer_costs() {
     );
     assert_eq!(
         vec![
-            price_groups[0].grouping_value.clone().unwrap(),
-            price_groups[0].secondary_grouping_value.clone().unwrap(),
+            price_groups[0].grouping_value.clone(),
+            price_groups[0].secondary_grouping_value.clone(),
         ],
         matrix_price.matrix_config.matrix_values[0].dimension_values
     );


### PR DESCRIPTION
If only a single dimension is defined in a matrix config, the second value in a dimension tuple is null (not absent or an empty string).