### PR TITLE
Support additional_emails field on the Customer type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased] <!-- #release:date -->
 
+* Support `additional_emails` field on `Customer`.
+
 ## [0.8.1] - 2024-01-12
 
 * Fix bug causing deserialization errors when `get_customer_costs` responses

--- a/src/client/customers.rs
+++ b/src/client/customers.rs
@@ -66,6 +66,9 @@ pub struct CreateCustomerRequest<'a> {
     pub name: &'a str,
     /// A valid email for the customer, to be used for notifications.
     pub email: &'a str,
+    /// Additional email addresses for this customer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_emails: Option<Vec<&'a str>>,
     /// The customer's timezone as an identifier from the IANA timezone
     /// database.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -102,6 +105,9 @@ pub struct UpdateCustomerRequest<'a> {
     /// A valid email for the customer, to be used for notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub email: Option<&'a str>,
+    /// Additional email addresses for this customer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_emails: Option<Vec<&'a str>>,
     /// The external payments or invoicing solution connected to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(flatten)]
@@ -152,6 +158,8 @@ pub struct Customer {
     pub name: String,
     /// A valid email for the customer, to be used for notifications.
     pub email: String,
+    /// Additional email addresses for this customer.
+    pub additional_emails: Vec<String>,
     /// The customer's timezone as an identifier from the IANA timezone
     /// database.
     pub timezone: String,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -145,6 +145,8 @@ async fn test_customers() {
     assert_eq!(customer.billing_address, None);
     assert_eq!(customer.shipping_address, None);
     assert_eq!(customer.tax_id, None);
+    let empty_emails: Vec<String> = vec![];
+    assert_eq!(customer.additional_emails, empty_emails);
 
     // Test fetching the customer by ID.
     let customer = client.get_customer(&customer.id).await.unwrap();
@@ -241,6 +243,37 @@ async fn test_customers() {
         .unwrap();
     assert_eq!(customer.email, "orb-testing+update-1@materialize.com");
     let customer = client.get_customer(&customer.id).await.unwrap();
+    assert_eq!(customer.email, "orb-testing+update-1@materialize.com");
+    let empty_emails: Vec<String> = vec![];
+    assert_eq!(customer.additional_emails, empty_emails);
+
+    // Test updating additional_emails by ID
+    let customer = client
+        .update_customer(
+            &customer.id,
+            &UpdateCustomerRequest {
+                additional_emails: Some(vec![
+                    "orb-testing+update-2@materialize.com",
+                    "orb-testing+update-3@materialize.com",
+                ]),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(customer
+        .additional_emails
+        .contains(&"orb-testing+update-2@materialize.com".to_string()));
+    assert!(customer
+        .additional_emails
+        .contains(&"orb-testing+update-3@materialize.com".to_string()));
+    let customer = client.get_customer(&customer.id).await.unwrap();
+    assert!(customer
+        .additional_emails
+        .contains(&"orb-testing+update-2@materialize.com".to_string()));
+    assert!(customer
+        .additional_emails
+        .contains(&"orb-testing+update-3@materialize.com".to_string()));
     assert_eq!(customer.email, "orb-testing+update-1@materialize.com");
 
     // Test updating the customer by external ID.


### PR DESCRIPTION
Support additional_emails on the Customer type

Orb reference docs

- Create https://docs.withorb.com/reference/create-customer
- Update https://docs.withorb.com/reference/update-customer