### PR TITLE
Migrate to CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,59 @@
+# Copyright 2020 SAP SE
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the
+# Contributor Assistant project. The original source code was retrieved on
+# July 31, 2024 from:
+#
+#     https://github.com/contributor-assistant/github-action/blob/master/README.md
+
+# Check if PR authors have signed the Materialize CLA, and if not have them sign
+# and record their signature. The CLA and signatures are stored in
+# https://github.com/MaterializeInc/cla
+
+name: CLA Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          remote-organization-name: MaterializeInc
+          remote-repository-name: cla
+          branch: main
+          path-to-signatures: signatures.v1.json
+          path-to-document: https://github.com/MaterializeInc/cla/blob/main/cla.md
+          allowlist: materialize-bot,materialize-bot-monitoring,dependabot[bot]
+          custom-notsigned-prcomment: Thank you for your submission! We really appreciate it. Like many source-available projects, we require that you sign our [Contributor License Agreement](https://github.com/MaterializeInc/cla/blob/main/cla.md) (CLA) before we can accept your contribution.<br><br>You can sign the CLA by posting a comment with the message below.
+          custom-pr-sign-comment: I have read the Contributor License Agreement (CLA) and I hereby sign the CLA.
+          custom-allsigned-prcomment: All contributors have signed the CLA.
+          lock-pullrequest-aftermerge: true


### PR DESCRIPTION
## Motivation

We need to swap over to the new CLA assistant. Copy over the GHA from the main Materialize repo.